### PR TITLE
Avoid stub.restore() in restoreMethod if !stub

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,9 @@ function restoreAllMethods(service) {
  */
 function restoreMethod(service, method) {
   if (services[service] && services[service].methodMocks[method]) {
-    services[service].methodMocks[method].stub.restore();
+    if (services[service].methodMocks[method].stub) {
+      services[service].methodMocks[method].stub.restore();
+    }
     delete services[service].methodMocks[method];
   } else {
     console.log('Method ' + service + ' was never instantiated yet you try to restore it.');


### PR DESCRIPTION
This is somewhat like #35 but for a different case. This patch fixes the errors I'm getting in `restore()` when a mocked method is never actually called between being mocked and being restored.
